### PR TITLE
feat(keycloak): add a jobspec for platform identity service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,18 +19,15 @@ repos:
     hooks:
       - id: commitlint
         stages: [commit-msg]
-        additional_dependencies: ['@commitlint/config-conventional', '@commitlint/cli']
+        additional_dependencies:
+          ["@commitlint/config-conventional", "@commitlint/cli"]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
       - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+        args: ["--baseline", ".secrets.baseline"]
 
-  - repo: https://github.com/tfsec/tfsec
-    rev: v1.28.14
-    hooks:
-      - id: tfsec-system
   - repo: local
     hooks:
       - id: format-jobspec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,12 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.2
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.25.0
+    rev: v9.26.0
     hooks:
       - id: commitlint
         stages: [commit-msg]

--- a/keycloak/platform-keycloak.nomad.hcl
+++ b/keycloak/platform-keycloak.nomad.hcl
@@ -1,15 +1,160 @@
+variable "platform_postgres_service" {
+  type    = string
+  default = "platform-data-plane-default"
+}
+
 job "keycloak" {
+  constraint {
+    attribute = "${meta.model}"
+    operator  = "="
+    value     = "Raspberry Pi 5 Model B Rev 1.1"
+  }
   datacenters = ["dc1"]
   type        = "service"
   vault {}
 
   group "keycloak" {
+
     network {
+      dns {
+        servers = ["172.17.0.1"]
+      }
+      # mode = "bridge"
       port "ui" {
         static = 8080
       }
       port "mgmt" {
         to = 9000
+      }
+    } // group network
+
+    task "db-init" {
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+      consul {}
+      driver = "docker"
+      config {
+        image   = "postgres:17.9-alpine"
+        command = "psql"
+        args = [
+          "-h", "${DB_ADDR}",
+          "-U", "${DB_USER}",
+          "-p", "${DB_PORT}",
+          "-f", "local/init-user.sql",
+          "-f", "local/init-db.sql"
+        ]
+        # dns_servers = ["127.0.0.1", "${attr.unique.network.ip-address}", "1.1.1.1"]
+      } // prestart task config
+
+      template {
+        destination = "local/init-user.sql"
+        data        = <<EOT
+      {{ with secret "hashiatho.me-v2/data_plane" }}
+      -- Create keycloak user if it doesn't exist
+      DO $$
+      BEGIN
+        CREATE USER {{ .Data.data.db_username }} WITH PASSWORD '{{ .Data.data.db_password }}';
+      EXCEPTION WHEN DUPLICATE_OBJECT THEN
+        NULL;
+      END
+      $$;
+      {{ end }}
+      EOT
+        perms       = "0644"
+      }
+
+      template {
+        destination = "local/init-db.sql"
+        data        = <<EOT
+{{ with secret "hashiatho.me-v2/keycloak" }}
+-- Create keycloak database if it doesn't exist
+CREATE DATABASE keycloak OWNER keycloak;
+
+-- Connect to keycloak database
+\c keycloak
+
+-- Create schema if it doesn't exist
+CREATE SCHEMA IF NOT EXISTS keycloak;
+
+-- Grant permissions on database
+GRANT CONNECT ON DATABASE keycloak TO keycloak;
+
+-- Grant permissions on schemas
+GRANT USAGE ON SCHEMA public TO keycloak;
+GRANT USAGE ON SCHEMA keycloak TO keycloak;
+GRANT CREATE ON SCHEMA public TO keycloak;
+GRANT CREATE ON SCHEMA keycloak TO keycloak;
+
+-- Grant permissions on existing tables
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO keycloak;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA keycloak TO keycloak;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO keycloak;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA keycloak TO keycloak;
+
+-- Set default privileges for future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA keycloak GRANT ALL ON TABLES TO keycloak;
+ALTER DEFAULT PRIVILEGES IN SCHEMA keycloak GRANT ALL ON SEQUENCES TO keycloak;
+{{ end }}
+EOT
+        perms       = "0644"
+      } // db init template
+
+      template {
+        data        = <<EOH
+{{ range service "primary.${var.platform_postgres_service}" }}
+DB_ADDR="{{ .Address }}"
+DB_PORT="{{ .Port }}"
+{{ end }}
+{{ with secret "hashiatho.me-v2/data_plane" }}
+DB_PASSWORD="{{ .Data.data.postgres_root_password }}"
+PGPASSWORD="{{ .Data.data.postgres_root_password }}"
+DB_USER="{{ .Data.data.postgres_root_user }}"
+{{ end }}
+          EOH
+        destination = "secrets/db.env"
+        env         = true
+        # wait {
+        #     min = "2s"
+        #     max = "10s"
+        # }
+      } // secrets template
+    }   // task
+
+    task "migration" {
+      consul {}
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+      driver = "exec"
+      template {
+        destination = "local/configure-db.sh"
+        perms       = "0700"
+        data        = <<EOT
+#!/bin/bash -eot
+echo "Migrating Realm"
+exit 0
+        EOT
+      }
+      // Remote bucket credentials
+      template {
+        data        = <<EOH
+  {{ with secret "hashiatho.me-v2/data/cloudflare" }}
+  AWS_ACCESS_KEY_ID = "{{ .Data.data.platform_state_bucket_access_key_id }}"
+  AWS_SECRET_ACCESS_KEY = "{{ .Data.data.platform_state_bucket_secret_access_key }}"
+  BUCKET_NAME = "{{ .Data.data.platform_state_bucket }}"
+  {{ end }}
+  EOH
+        destination = "secrets/r2.env"
+        env         = true
+      }
+      config {
+        command = "/bin/bash"
+        args    = ["local/configure-db.sh"]
       }
     }
 
@@ -18,6 +163,7 @@ job "keycloak" {
       service {
         name = "platform-keycloak"
         port = "mgmt"
+        tags = [""]
         check {
           name     = "keycloak-started"
           type     = "http"
@@ -42,7 +188,7 @@ job "keycloak" {
       }
       template {
         data        = <<EOF
-{{ range service "master.default" }}
+{{ range service "primary.${var.platform_postgres_service}" }}
 KC_DB_URL="jdbc:postgresql://{{ .Address }}:{{ .Port }}/keycloak"
 {{ end }}
 {{ with secret "hashiatho.me-v2/data/keycloak" }}
@@ -81,7 +227,7 @@ EOF
 echo ${KC_BOOTSTRAP_ADMIN_USERNAME}
 env
 /opt/keycloak/bin/kc.sh build
-/opt/keycloak/bin/kc.sh bootstrap-admin user --username admain --password:env KC_BOOTSTRAP_ADMIN_PASSWORD
+/opt/keycloak/bin/kc.sh bootstrap-admin user --username admin --password:env KC_BOOTSTRAP_ADMIN_PASSWORD
 /opt/keycloak/bin/kc.sh start --optimized
         EOT
       }
@@ -90,6 +236,6 @@ env
         entrypoint = ["local/start.sh"]
         ports      = ["ui", "mgmt"]
       }
-    }
-  }
-}
+    } // task
+  }   // group
+}     // job

--- a/keycloak/platform-keycloak.nomad.hcl
+++ b/keycloak/platform-keycloak.nomad.hcl
@@ -105,7 +105,7 @@ EOT
 
       template {
         data        = <<EOH
-{{ range service "primary.${var.platform_postgres_service}" }}
+{{ range service "primary.platform-data-plane-default" }}
 DB_ADDR="{{ .Address }}"
 DB_PORT="{{ .Port }}"
 {{ end }}
@@ -130,20 +130,26 @@ DB_USER="{{ .Data.data.postgres_root_user }}"
         hook    = "prestart"
         sidecar = false
       }
-      driver = "exec"
+      driver = "docker"
       template {
-        destination = "local/configure-db.sh"
-        perms       = "0700"
+        destination = "local/rclone.conf"
+        perms       = "0644"
         data        = <<EOT
-#!/bin/bash -eot
-echo "Migrating Realm"
-exit 0
+{{ with secret "hashiatho.me-v2/cloudflare" }}
+[r2]
+type = s3
+provider = Cloudflare
+access_key_id = {{ .Data.data.platform_state_bucket_access_key_id }}
+secret_access_key = {{ .Data.data.platform_state_bucket_secret_access_key }}
+endpoint = {{ .Data.data.platform_access_bucket_endpoint }}
+acl = private
+{{ end }}
         EOT
       }
       // Remote bucket credentials
       template {
         data        = <<EOH
-  {{ with secret "hashiatho.me-v2/data/cloudflare" }}
+  {{ with secret "hashiatho.me-v2/cloudflare" }}
   AWS_ACCESS_KEY_ID = "{{ .Data.data.platform_state_bucket_access_key_id }}"
   AWS_SECRET_ACCESS_KEY = "{{ .Data.data.platform_state_bucket_secret_access_key }}"
   BUCKET_NAME = "{{ .Data.data.platform_state_bucket }}"
@@ -153,8 +159,8 @@ exit 0
         env         = true
       }
       config {
-        command = "/bin/bash"
-        args    = ["local/configure-db.sh"]
+        image = "rclone/rclone:latest"
+        args  = ["--config", "/local/rclone.conf", "tree", "r2:${BUCKET_NAME}"]
       }
     }
 
@@ -228,6 +234,11 @@ echo ${KC_BOOTSTRAP_ADMIN_USERNAME}
 env
 /opt/keycloak/bin/kc.sh build
 /opt/keycloak/bin/kc.sh bootstrap-admin user --username admin --password:env KC_BOOTSTRAP_ADMIN_PASSWORD
+# Create adamin user
+# Create client for Terraform
+{{ with secret "hashiatho.me-v2/keycloak" }}
+# $ kcadm.sh create clients -r master -s clientId=terraform -s enabled=true -s clientAuthenticatorType=client-secret -s secret={{ .Data.data.terraform_client_id }}
+{{ end }}
 /opt/keycloak/bin/kc.sh start --optimized
         EOT
       }

--- a/keycloak/platform-keycloak.nomad.hcl
+++ b/keycloak/platform-keycloak.nomad.hcl
@@ -15,6 +15,12 @@ job "keycloak" {
 
   group "keycloak" {
 
+    restart {
+      interval         = "5m"
+      delay            = "30s"
+      render_templates = true
+    }
+
     network {
       dns {
         servers = ["172.17.0.1"]
@@ -27,6 +33,8 @@ job "keycloak" {
         to = 9000
       }
     } // group network
+
+
 
     task "db-init" {
       lifecycle {
@@ -51,7 +59,7 @@ job "keycloak" {
       template {
         destination = "local/init-user.sql"
         data        = <<EOT
-      {{ with secret "hashiatho.me-v2/data_plane" }}
+      {{ with secret "hashiatho.me-v2/keycloak" }}
       -- Create keycloak user if it doesn't exist
       DO $$
       BEGIN

--- a/keycloak/platform-keycloak.nomad.hcl
+++ b/keycloak/platform-keycloak.nomad.hcl
@@ -1,0 +1,95 @@
+job "keycloak" {
+  datacenters = ["dc1"]
+  type        = "service"
+  vault {}
+
+  group "keycloak" {
+    network {
+      port "ui" {
+        static = 8080
+      }
+      port "mgmt" {
+        to = 9000
+      }
+    }
+
+    task "keycloak" {
+      consul {}
+      service {
+        name = "platform-keycloak"
+        port = "mgmt"
+        check {
+          name     = "keycloak-started"
+          type     = "http"
+          path     = "/health/started"
+          interval = "30s"
+          timeout  = "2s"
+        }
+        check {
+          name     = "keycloak-liveness"
+          type     = "http"
+          path     = "/health/live"
+          interval = "30s"
+          timeout  = "2s"
+        }
+        check {
+          name     = "keycloak-readiness"
+          type     = "http"
+          path     = "/health/ready"
+          interval = "30s"
+          timeout  = "2s"
+        }
+      }
+      template {
+        data        = <<EOF
+{{ range service "master.default" }}
+KC_DB_URL="jdbc:postgresql://{{ .Address }}:{{ .Port }}/keycloak"
+{{ end }}
+{{ with secret "hashiatho.me-v2/data/keycloak" }}
+KC_DB_PASSWORD="{{ .Data.data.db_password }}"
+KC_DB_USERNAME="{{ .Data.data.db_username }}"
+KC_BOOTSTRAP_ADMIN_USERNAME="{{ .Data.data.admin_username }}"
+KC_BOOTSTRAP_ADMIN_PASSWORD="{{ .Data.data.admin_password }}"
+{{ end }}
+EOF
+        destination = "secrets/keycloak.env"
+        env         = true
+      }
+      resources {
+        memory = 2048
+        cpu    = 2000
+      }
+      driver = "docker"
+      env {
+        KC_DB                             = "postgres"
+        KC_DB_USERNAME                    = "keycloak"
+        KC_DB_SCHEMA                      = "keycloak"
+        KC_HEALTH_ENABLED                 = true
+        KC_METRICS_ENABLED                = true
+        KC_HTTP_ENABLED                   = true
+        KC_HOSTNAME_STRICT                = false
+        KC_HTTP_MANAGEMENT_HEALTH_ENABLED = true
+        KC_HTTP_MANAGEMENT_SCHEME         = "http"
+      }
+
+      template {
+        destination = "local/start.sh"
+        change_mode = "restart"
+        perms       = "0777"
+        data        = <<EOT
+#!/bin/bash
+echo ${KC_BOOTSTRAP_ADMIN_USERNAME}
+env
+/opt/keycloak/bin/kc.sh build
+/opt/keycloak/bin/kc.sh bootstrap-admin user --username admain --password:env KC_BOOTSTRAP_ADMIN_PASSWORD
+/opt/keycloak/bin/kc.sh start --optimized
+        EOT
+      }
+      config {
+        image      = "quay.io/keycloak/keycloak:26.7.2"
+        entrypoint = ["local/start.sh"]
+        ports      = ["ui", "mgmt"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Only the workload is included here.
It depends on an existing database server - currently provided by the default patroni deployment in the platform data plane.

Further improvements:

- [x] Add database initialisation prestart task
- [x] add provisioning script for master realm configuration in poststart task
- [x] Add a realm backup and snapshot in poststop configuration or sidecar.